### PR TITLE
integrate oghliner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var gulp = require('gulp');
+var oghliner = require('oghliner');
+
+gulp.task('default', ['build', 'offline']);
+
+// The files comprised by the app.
+var srcFiles = [
+  '*.html',
+  'css/*.css',
+  'fonts/*.*',
+  'js/*.js',
+];
+
+// The directory in which the app will be built, and from which it is offlined
+// and deployed.  This is also the prefix that will be stripped from the front
+// of paths cached by the offline worker, so it should include a trailing slash
+// to ensure the leading slash of the path is stripped, i.e. to ensure
+// dist/css/style.css becomes css/style.css, not /css/style.css.
+var rootDir = 'dist/';
+
+gulp.task('build', function(callback) {
+  return gulp.src(srcFiles, { base: '.' }).pipe(gulp.dest(rootDir));
+});
+
+gulp.task('offline', ['build'], function(callback) {
+  oghliner.offline({
+    rootDir: rootDir,
+    fileGlobs: srcFiles,
+  }, callback);
+});
+
+gulp.task('deploy', function(callback) {
+  oghliner.deploy({
+    rootDir: rootDir,
+  }, callback);
+});

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
 	<script src="js/jquery.min.js" type="text/javascript"></script>	
 	<script src="js/bootstrap.js" type="text/javascript"></script>	
 	<script src="js/app.js" type="text/javascript"></script>	
+	<script src="js/offline-manager.js"></script>
 
 </body>
 

--- a/js/offline-manager.js
+++ b/js/offline-manager.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('offline-worker.js').then(function(registration) {
+    console.log('offline worker registered');
+  });
+}

--- a/js/server.js
+++ b/js/server.js
@@ -73,7 +73,7 @@ app.use(session({
 
 // this will cache the index.html for a day, which is bad
 // but it caches the bootstrap.css for a day which is good.
-
+// XXX Make this work in a GitHub Pages subdirectory (*.github.io/mc-choir/).
 app.use("/", express.static('client', { maxage: 86400000 }));
 app.use("/js", express.static('js', { maxage: 86400000 }));
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mc-choir",
+  "version": "0.1.0",
+  "description": "web app for participants in a musique concrete choir for WAC 2016",
+  "main": "index.js",
+  "dependencies": {
+    "gulp": "^3.9.0",
+    "oghliner": "^0.3.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wfwalker/mc-choir.git"
+  },
+  "author": "Bill Walker",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wfwalker/mc-choir/issues"
+  },
+  "homepage": "https://github.com/wfwalker/mc-choir#readme"
+}


### PR DESCRIPTION
@wfwalker This integrates the latest version oghliner to offline the app and deploy it to GitHub Pages:

``` bash
npm install # only need to do this once
gulp # build app and offline it
gulp deploy
```

There's preliminary support for auto-deployment via Travis, although it's still a chore to configure. Read more about it here: https://github.com/mozilla/oghliner#automatic-deployment-via-travis. Improvements to come; in the meantime, you might be better off simply deploying via `gulp && gulp deploy` locally.
